### PR TITLE
fix: add back missing header in VTXParser.cpp

### DIFF
--- a/source/VTXParser.cpp
+++ b/source/VTXParser.cpp
@@ -1,5 +1,6 @@
 #include "../MDLParser.h"
 
+#include <cstdlib>
 #include <cstring>
 
 #include "Ints.h"


### PR DESCRIPTION
Sorry, I just realized I accidentally deleted `#include <cstdlib>` in the VTX parser 😅 

With this change it compiles fine, I didn't notice it until now because I used that header too

Proof it compiles: https://github.com/craftablescience/VPKEdit/actions/runs/6869848580