### PR TITLE
Normalise texture directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(MDLParser
         source/mdl.hpp
         source/accessors.hpp
         source/accessors.cpp
+        source/helpers/normalise-directory.hpp
+        source/helpers/normalise-directory.cpp
 )
 
 target_include_directories(

--- a/source/helpers/normalise-directory.cpp
+++ b/source/helpers/normalise-directory.cpp
@@ -1,0 +1,9 @@
+#include "normalise-directory.hpp"
+#include <regex>
+
+namespace MdlParser {
+
+  std::string getNormalisedDirectory(const std::string& raw) {
+    return std::regex_replace(raw, std::regex("\\\\"), "/");
+  }
+}

--- a/source/helpers/normalise-directory.hpp
+++ b/source/helpers/normalise-directory.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <string>
+
+namespace MdlParser {
+  [[nodiscard]] std::string getNormalisedDirectory(const std::string& raw);
+}

--- a/source/mdl.cpp
+++ b/source/mdl.cpp
@@ -1,4 +1,5 @@
 #include "mdl.hpp"
+#include "helpers/normalise-directory.hpp"
 #include "helpers/offset-data-view.hpp"
 #include "structs/vvd.hpp"
 
@@ -58,7 +59,8 @@ namespace MdlParser {
       for (const auto textureDirectoryOffset : data.parseStructArrayWithoutOffsets<int32_t>(
              header.textureDirOffset, header.textureDirCount, "Failed to parse MDL texture directory list"
            )) {
-        textureDirectories.push_back(data.parseString(textureDirectoryOffset, "Failed to parse MDL texture directory"));
+        const auto rawDirectory = data.parseString(textureDirectoryOffset, "Failed to parse MDL texture directory");
+        textureDirectories.push_back(getNormalisedDirectory(rawDirectory));
       }
 
       return std::move(textureDirectories);


### PR DESCRIPTION
Replaces double backslashes in texture directory paths with a single forward slash