### PR TITLE
 #261 - Refactor to use std::span

### DIFF
--- a/source/helpers/offset-data-view.cpp
+++ b/source/helpers/offset-data-view.cpp
@@ -1,33 +1,24 @@
 #include "offset-data-view.hpp"
 
 namespace MdlParser {
-  OffsetDataView::OffsetDataView(const std::weak_ptr<std::vector<std::byte>>& data) : data(data), offset(0) {}
+  OffsetDataView::OffsetDataView(const std::span<const std::byte> data) : data(data), offset(0) {}
 
-  OffsetDataView::OffsetDataView(const OffsetDataView& from, const size_t newOffset) :
-    data(from.data), offset(newOffset) {}
+  OffsetDataView::OffsetDataView(const OffsetDataView& from, const size_t newOffset)
+    : data(from.data), offset(newOffset) {}
 
   OffsetDataView OffsetDataView::withOffset(const size_t newOffset) const {
     return OffsetDataView(*this, newOffset);
   }
 
   std::string OffsetDataView::parseString(const size_t relativeOffset, const char* errorMessage) const {
-    const auto lockedData = getLockedData();
     const auto absoluteOffset = offset + relativeOffset;
 
-    for (size_t i = absoluteOffset; i < lockedData->size(); i++) {
-      if (lockedData->at(i) == std::byte(0)) {
-        return reinterpret_cast<const char*>(&lockedData->at(absoluteOffset));
+    for (auto i = absoluteOffset; i < data.size(); i++) {
+      if (data[i] == static_cast<std::byte>(0)) {
+        return reinterpret_cast<const char*>(&data[absoluteOffset]);
       }
     }
 
     throw OutOfBoundsAccess(errorMessage);
-  }
-
-  std::shared_ptr<std::vector<std::byte>> OffsetDataView::getLockedData() const {
-    if (data.expired()) {
-      throw std::runtime_error("Attempted to lock an expired weak_ptr to underlying data");
-    }
-
-    return data.lock();
   }
 }

--- a/source/mdl.hpp
+++ b/source/mdl.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "./structs/mdl.hpp"
-#include <cstdint>
-#include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
+#include "./structs/mdl.hpp"
 
 namespace MdlParser {
   /**
@@ -123,13 +122,14 @@ namespace MdlParser {
 
     /**
      * Parses a .mdl file contained in the given buffer into an easier to use and more modern structure.
-     * No ownership of the data is taken as all contents are copied into new structs.
+     * No ownership of the data is taken but all contents are copied into new structs, so the Mdl instance may outlive data.
      *
      * @param data
      * @param checksum Optional checksum to validate against the header's
      */
     explicit Mdl(
-      const std::weak_ptr<std::vector<std::byte>>& data, const std::optional<int32_t>& checksum = std::nullopt
+      std::span<const std::byte> data,
+      const std::optional<int32_t>& checksum = std::nullopt
     );
 
     /**

--- a/source/vtx.hpp
+++ b/source/vtx.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "enums.hpp"
-#include "structs/vtx.hpp"
-#include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
+#include "enums.hpp"
+#include "structs/vtx.hpp"
 
 namespace MdlParser {
   /**
@@ -126,13 +126,14 @@ namespace MdlParser {
 
     /**
      * Parses a .vtx file contained in the given buffer into an easier to use and more modern structure.
-     * No ownership of the data is taken as all contents are copied into new structs.
+     * No ownership of the data is taken but all contents are copied into new structs, so the Vtx can safely outlive data.
      *
      * @param data
      * @param checksum Optional checksum to validate against the header's
      */
     explicit Vtx(
-      const std::weak_ptr<std::vector<std::byte>>& data, const std::optional<int32_t>& checksum = std::nullopt
+      std::span<const std::byte> data,
+      const std::optional<int32_t>& checksum = std::nullopt
     );
 
     /**

--- a/source/vvd.hpp
+++ b/source/vvd.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "structs/vvd.hpp"
-#include <memory>
 #include <optional>
+#include <span>
 #include <vector>
+#include "structs/vvd.hpp"
 
 namespace MdlParser {
   /**
@@ -19,7 +19,8 @@ namespace MdlParser {
      * @param checksum Optional checksum to validate against the header's.
      */
     explicit Vvd(
-      const std::weak_ptr<std::vector<std::byte>>& data, const std::optional<int32_t>& checksum = std::nullopt
+      std::span<const std::byte> data,
+      const std::optional<int32_t>& checksum = std::nullopt
     );
 
     /**


### PR DESCRIPTION
Part of the pre-networking TASBox refactor. Use of std::span brings this into line with newer parser changes

Also applies CLion Nova formatting (instead of clang-format) and resolves warnings - both in touched files only